### PR TITLE
Changed minimum length of variable's name from 3 to 2

### DIFF
--- a/pmdMain.xml
+++ b/pmdMain.xml
@@ -15,6 +15,11 @@
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="OnlyOneReturn"/>
     </rule>
+    <rule ref="category/java/codestyle.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="2"/>
+        </properties>
+    </rule>
 
     <rule ref="category/java/design.xml">
         <exclude name="DataClass"/>

--- a/pmdTest.xml
+++ b/pmdTest.xml
@@ -19,6 +19,11 @@
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="PrematureDeclaration"/>
     </rule>
+    <rule ref="category/java/codestyle.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="2"/>
+        </properties>
+    </rule>
 
     <rule ref="category/java/design.xml">
         <exclude name="DataClass"/>


### PR DESCRIPTION
Closes #46
Fixes minimum length of variable's names in rule "ShortVariable" to be sure variables like "id" are legit