### PR TITLE
Disabled 'ImplicitFunctionalInterface' rule

### DIFF
--- a/pmdMain.xml
+++ b/pmdMain.xml
@@ -6,6 +6,7 @@
     <description>Rules</description>
     <rule ref="category/java/bestpractices.xml">
         <exclude name="RelianceOnDefaultCharset"/>
+        <exclude name="ImplicitFunctionalInterface"/>
     </rule>
 
     <rule ref="category/java/codestyle.xml">

--- a/pmdTest.xml
+++ b/pmdTest.xml
@@ -6,6 +6,7 @@
     <description>Rules</description>
     <rule ref="category/java/bestpractices.xml">
         <exclude name="AvoidPrintStackTrace"/>
+        <exclude name="ImplicitFunctionalInterface"/>
         <exclude name="LooseCoupling"/>
         <exclude name="PreserveStackTrace"/>
         <exclude name="RelianceOnDefaultCharset"/>


### PR DESCRIPTION
Closes #47
Deleted ImplicitFunctionalInterface rule from checks because our project won't use them and won't have need in annotating them. Lambdas in Java = poverty