### PR TITLE
Added 10 seconds timer

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -26,4 +26,4 @@ jobs:
           script: |
             cd /home/${{ secrets.SSH_USER }}/photostudio
             docker compose -f docker-compose.prod.yml pull app
-            docker rollout -f docker-compose.prod.yml app
+            docker rollout -f docker-compose.prod.yml --wait-after-healthy 10 app


### PR DESCRIPTION
Added 10 seconds timer after new containers are healthy in docker rollout so traefik guaranteed connects to new containers in time before old ones shuts down
Because of that requests won't stay idle in wait for new container to be in use